### PR TITLE
Update edn-rs and use absolute paths in macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ proc-macro = true
 syn = "1.0"
 quote = "1.0"
 proc-macro2 = "1.0"
-edn-rs = "0.14.2"
+edn-rs = "0.15.0"
 
 [dev-dependencies]
 trybuild = { version = "1.0", features = ["diff"] }

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -19,8 +19,8 @@ fn expand_struct(struct_name: &Ident, data_struct: &DataStruct) -> TokenStream2 
 
     quote! {
         impl edn_rs::Deserialize for #struct_name {
-            fn deserialize(edn: &edn_rs::Edn) -> Result<Self, edn_rs::EdnError> {
-                Ok(Self {
+            fn deserialize(edn: &edn_rs::Edn) -> std::result::Result<Self, edn_rs::EdnError> {
+                std::result::Result::Ok(Self {
                     #deserialized_fields
                 })
             }
@@ -35,23 +35,23 @@ fn expand_enum(enum_name: &Ident, data_enum: &DataEnum) -> TokenStream2 {
 
     quote! {
         impl edn_rs::Deserialize for #enum_name {
-            fn deserialize(edn: &edn_rs::Edn) -> Result<Self, edn_rs::EdnError> {
+            fn deserialize(edn: &edn_rs::Edn) -> std::result::Result<Self, edn_rs::EdnError> {
                 match edn {
                     edn_rs::Edn::Key(k) => match &k[..] {
                         #deserialized_variants
-                        _ => Err(edn_rs::EdnError::Deserialize(format!(
+                        _ => std::result::Result::Err(edn_rs::EdnError::Deserialize(format!(
                                 "couldn't convert {} keyword into enum",
                                 k
                         ))),
                     },
                     edn_rs::Edn::Str(s) => match &s[..] {
                         #deserialized_variants
-                        _ => Err(edn_rs::EdnError::Deserialize(format!(
+                        _ => std::result::Result::Err(edn_rs::EdnError::Deserialize(format!(
                                 "couldn't convert {} string into enum",
                                 s
                         ))),
                     },
-                    _ => Err(edn_rs::EdnError::Deserialize(format!(
+                    _ => std::result::Result::Err(edn_rs::EdnError::Deserialize(format!(
                                 "couldn't convert {} into enum",
                                 edn
                     ))),

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -18,7 +18,7 @@ pub fn generate_variant_deserialization(
             let keyword = to_edn_keyword(format!("{}/{}", quote! {#enum_name}, quote! {#name}));
 
             quote! {
-                #keyword => Ok(Self::#name),
+                #keyword => std::result::Result::Ok(Self::#name),
             }
         })
         .collect()

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -26,8 +26,8 @@ fn expand_struct(struct_name: &Ident, data_struct: &DataStruct) -> TokenStream2 
 
     quote! {
         impl edn_rs::Serialize for #struct_name {
-            fn serialize(self) -> String {
-                let mut s = String::new();
+            fn serialize(self) -> std::string::String {
+                let mut s = std::string::String::new();
                 s.push_str("{ ");
                 #(s.push_str(&#it);)*
                 s.push_str("}");
@@ -50,7 +50,7 @@ fn expand_enum(enum_name: &Ident, data_enum: &DataEnum) -> TokenStream2 {
 
     quote! {
         impl edn_rs::Serialize for #enum_name {
-            fn serialize(self) -> String {
+            fn serialize(self) -> std::string::String {
                 match self {
                     #(#it)*
                 }

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -18,7 +18,7 @@ pub fn generate_field_deserialization(fields: &Punctuated<Field, Comma>) -> Toke
             let keyword = to_edn_keyword(format!("{}", quote! {#name}));
 
             quote! {
-                #name: edn_rs::Deserialize::deserialize(&edn[#keyword])?,
+                #name: edn_rs::from_edn(&edn[#keyword])?,
             }
         })
         .collect()


### PR DESCRIPTION
This Pull Request does two things:

- Updates `edn-rs` to `0.15.0`;
- Uses absolute paths in macros because non absolute paths can be replaced and induce error. So this is a best practice in proc macros that we have to use.