### PR TITLE
Enum: support composed names

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,51 @@ fn main() -> Result<(), EdnError> {
     Ok(())
 }
 ```
+
+With more complexity using `.`, `-` and `/` on EDN conversions:
+
+```rust
+use edn_derive::{Deserialize, Serialize};
+use edn_rs::EdnError;
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+enum AccountType {
+    Basic,
+    Premium,
+    PremiumPlus,
+}
+
+#[allow(non_snake_case)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+struct Account {
+    crux__db___id: String,
+    account___amount: usize,
+    account_type: AccountType,
+}
+
+fn main() -> Result<(), EdnError> {
+    let account = Account {
+        crux__db___id: "123".to_string(),
+        account___amount: 42,
+        account_type: AccountType::PremiumPlus,
+    };
+
+    let account_edn_str =
+        "{ :crux.db/id \"123\", :account/amount 42, :account-type :account-type/premium-plus, }";
+
+    assert_eq!(edn_rs::to_string(account), account_edn_str);
+
+    let account: Account = edn_rs::from_str(account_edn_str)?;
+
+    assert_eq!(
+        account,
+        Account {
+            crux__db___id: "123".to_string(),
+            account___amount: 42,
+            account_type: AccountType::PremiumPlus,
+        }
+    );
+
+    Ok(())
+}
+```

--- a/src/edn.rs
+++ b/src/edn.rs
@@ -63,3 +63,19 @@ fn test_camel_to_kebab() {
     assert_eq!(camel_to_kebab("CoolText"), "cool-text");
     assert_eq!(camel_to_kebab("Nice"), "nice");
 }
+
+pub fn enum_to_keyword(enum_name: &str, variant_name: &str) -> String {
+    let mut keyword = String::from(':');
+    keyword.push_str(&camel_to_kebab(enum_name));
+    keyword.push('/');
+    keyword.push_str(&camel_to_kebab(variant_name));
+    keyword
+}
+
+#[test]
+fn test_enum_to_keyword() {
+    assert_eq!(
+        enum_to_keyword("EnumName", "EnumVariant"),
+        ":enum-name/enum-variant"
+    );
+}

--- a/src/edn.rs
+++ b/src/edn.rs
@@ -1,4 +1,4 @@
-pub fn to_edn_keyword(field_name: String) -> String {
+pub fn field_to_keyword(field_name: String) -> String {
     let mut keyword = field_name
         .to_lowercase()
         .replace("___", "/")
@@ -9,34 +9,34 @@ pub fn to_edn_keyword(field_name: String) -> String {
 }
 
 #[test]
-fn test_to_edn_keyword_lowercase() {
-    assert_eq!(to_edn_keyword("name".to_string()), ":name");
-    assert_eq!(to_edn_keyword("crux__db___id".to_string()), ":crux.db/id");
+fn test_field_to_keyword_lowercase() {
+    assert_eq!(field_to_keyword("name".to_string()), ":name");
+    assert_eq!(field_to_keyword("crux__db___id".to_string()), ":crux.db/id");
     assert_eq!(
-        to_edn_keyword("account___amount".to_string()),
+        field_to_keyword("account___amount".to_string()),
         ":account/amount"
     );
-    assert_eq!(to_edn_keyword("tx___tx_time".to_string()), ":tx/tx-time");
+    assert_eq!(field_to_keyword("tx___tx_time".to_string()), ":tx/tx-time");
 }
 
 #[test]
-fn test_to_edn_keyword_mixedcase() {
-    assert_eq!(to_edn_keyword("Name".to_string()), ":name");
-    assert_eq!(to_edn_keyword("Crux__dB___id".to_string()), ":crux.db/id");
+fn test_field_to_keyword_mixedcase() {
+    assert_eq!(field_to_keyword("Name".to_string()), ":name");
+    assert_eq!(field_to_keyword("Crux__dB___id".to_string()), ":crux.db/id");
     assert_eq!(
-        to_edn_keyword("acCount___amouNt".to_string()),
+        field_to_keyword("acCount___amouNt".to_string()),
         ":account/amount"
     );
-    assert_eq!(to_edn_keyword("tX___tx_timE".to_string()), ":tx/tx-time");
+    assert_eq!(field_to_keyword("tX___tx_timE".to_string()), ":tx/tx-time");
 }
 
 #[test]
-fn test_to_edn_keyword_uppercase() {
-    assert_eq!(to_edn_keyword("NAME".to_string()), ":name");
-    assert_eq!(to_edn_keyword("CRUX__DB___ID".to_string()), ":crux.db/id");
+fn test_field_to_keyword_uppercase() {
+    assert_eq!(field_to_keyword("NAME".to_string()), ":name");
+    assert_eq!(field_to_keyword("CRUX__DB___ID".to_string()), ":crux.db/id");
     assert_eq!(
-        to_edn_keyword("ACCOUNT___AMOUNT".to_string()),
+        field_to_keyword("ACCOUNT___AMOUNT".to_string()),
         ":account/amount"
     );
-    assert_eq!(to_edn_keyword("TX___TX_TIME".to_string()), ":tx/tx-time");
+    assert_eq!(field_to_keyword("TX___TX_TIME".to_string()), ":tx/tx-time");
 }

--- a/src/edn.rs
+++ b/src/edn.rs
@@ -40,3 +40,26 @@ fn test_field_to_keyword_uppercase() {
     );
     assert_eq!(field_to_keyword("TX___TX_TIME".to_string()), ":tx/tx-time");
 }
+
+fn camel_to_kebab(s: &str) -> String {
+    s.chars()
+        .enumerate()
+        .fold(String::new(), |mut kebab, (i, c)| {
+            if c.is_uppercase() {
+                if i != 0 {
+                    kebab.push('-');
+                }
+                kebab.push_str(&c.to_lowercase().collect::<String>());
+            } else {
+                kebab.push(c);
+            }
+
+            kebab
+        })
+}
+
+#[test]
+fn test_camel_to_kebab() {
+    assert_eq!(camel_to_kebab("CoolText"), "cool-text");
+    assert_eq!(camel_to_kebab("Nice"), "nice");
+}

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -1,4 +1,4 @@
-use crate::edn::to_edn_keyword;
+use crate::edn;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use syn::{punctuated::Punctuated, token::Comma, DataEnum, Ident, Variant};
@@ -15,7 +15,8 @@ pub fn generate_variant_deserialization(
         .iter()
         .map(|v| {
             let name = &v.ident;
-            let keyword = to_edn_keyword(format!("{}/{}", quote! {#enum_name}, quote! {#name}));
+            let keyword =
+                edn::field_to_keyword(format!("{}/{}", quote! {#enum_name}, quote! {#name}));
 
             quote! {
                 #keyword => std::result::Result::Ok(Self::#name),

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -15,8 +15,10 @@ pub fn generate_variant_deserialization(
         .iter()
         .map(|v| {
             let name = &v.ident;
-            let keyword =
-                edn::field_to_keyword(format!("{}/{}", quote! {#enum_name}, quote! {#name}));
+            let keyword = edn::enum_to_keyword(
+                &quote! {#enum_name}.to_string(),
+                &quote! {#name}.to_string(),
+            );
 
             quote! {
                 #keyword => std::result::Result::Ok(Self::#name),

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -1,4 +1,4 @@
-use crate::edn::to_edn_keyword;
+use crate::edn;
 use crate::enums::get_enum_variants;
 use crate::structs::get_struct_fields;
 use proc_macro2::TokenStream as TokenStream2;
@@ -18,7 +18,7 @@ fn expand_struct(struct_name: &Ident, data_struct: &DataStruct) -> TokenStream2 
 
     let it = struct_fields.iter().map(|field| {
         let name = &field.ident;
-        let keyword = to_edn_keyword(format!("{}", quote! {#name}));
+        let keyword = edn::field_to_keyword(format!("{}", quote! {#name}));
         quote! {
             format!("{} {}, ", #keyword, self.#name.serialize())
         }
@@ -42,7 +42,7 @@ fn expand_enum(enum_name: &Ident, data_enum: &DataEnum) -> TokenStream2 {
 
     let it = enum_variants.iter().map(|variant| {
         let name = &variant.ident;
-        let keyword = to_edn_keyword(format!("{}/{}", quote! {#enum_name}, quote! {#name}));
+        let keyword = edn::field_to_keyword(format!("{}/{}", quote! {#enum_name}, quote! {#name}));
         quote! {
             Self::#name => #keyword.to_string(),
         }

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -42,7 +42,10 @@ fn expand_enum(enum_name: &Ident, data_enum: &DataEnum) -> TokenStream2 {
 
     let it = enum_variants.iter().map(|variant| {
         let name = &variant.ident;
-        let keyword = edn::field_to_keyword(format!("{}/{}", quote! {#enum_name}, quote! {#name}));
+        let keyword = edn::enum_to_keyword(
+            &quote! {#enum_name}.to_string(),
+            &quote! {#name}.to_string(),
+        );
         quote! {
             Self::#name => #keyword.to_string(),
         }

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1,4 +1,4 @@
-use crate::edn::to_edn_keyword;
+use crate::edn;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use syn::{punctuated::Punctuated, token::Comma, DataStruct, Field, Fields};
@@ -15,7 +15,7 @@ pub fn generate_field_deserialization(fields: &Punctuated<Field, Comma>) -> Toke
         .iter()
         .map(|f| {
             let name = &f.ident;
-            let keyword = to_edn_keyword(format!("{}", quote! {#name}));
+            let keyword = edn::field_to_keyword(format!("{}", quote! {#name}));
 
             quote! {
                 #name: edn_rs::from_edn(&edn[#keyword])?,

--- a/tests/complex.rs
+++ b/tests/complex.rs
@@ -1,0 +1,43 @@
+use edn_derive::{Deserialize, Serialize};
+use edn_rs::EdnError;
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+enum AccountType {
+    Basic,
+    Premium,
+    PremiumPlus,
+}
+
+#[allow(non_snake_case)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+struct Account {
+    crux__db___id: String,
+    account___amount: usize,
+    account_type: AccountType,
+}
+
+fn main() -> Result<(), EdnError> {
+    let account = Account {
+        crux__db___id: "123".to_string(),
+        account___amount: 42,
+        account_type: AccountType::PremiumPlus,
+    };
+
+    let account_edn_str =
+        "{ :crux.db/id \"123\", :account/amount 42, :account-type :account-type/premium-plus, }";
+
+    assert_eq!(edn_rs::to_string(account), account_edn_str);
+
+    let account: Account = edn_rs::from_str(account_edn_str)?;
+
+    assert_eq!(
+        account,
+        Account {
+            crux__db___id: "123".to_string(),
+            account___amount: 42,
+            account_type: AccountType::PremiumPlus,
+        }
+    );
+
+    Ok(())
+}

--- a/tests/progress.rs
+++ b/tests/progress.rs
@@ -4,4 +4,5 @@ fn tests() {
     t.pass("tests/serialize.rs");
     t.pass("tests/deserialize.rs");
     t.pass("tests/both_ways.rs");
+    t.pass("tests/complex.rs");
 }


### PR DESCRIPTION
- Renames old `to_edn_keyword` to `field_to_keyword`, since it only works for field names on structs;
- Adds `camel_to_kebab` utility function;
- Adds `enum_to_keyword` function for converting an Rust `enum name` + `enum variant` to a valid `keyword`;
- Adds new test for complex conversions, including good old underscores to `.`, `/` and `-` as well as the new composed enum names;
- Adds this new test as example on README.md to ease use.