### PR TITLE
Revert "trait Serialize uses reference to self instead of move. "

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,14 +20,14 @@ name = "tests"
 path = "tests/progress.rs"
 
 [dependencies]
-syn = "2.0"
+syn = "1.0"
 quote = "1.0"
 proc-macro2 = "1.0"
 edn-rs = { git = "https://github.com/edn-rs/edn-rs.git" } # TODO lock in version once stable
 
 [dev-dependencies]
 trybuild = { version = "1.0", features = ["diff"] }
-criterion = "0.5"
+criterion = "0.3"
 
 [dev-dependencies.cargo-husky]
 version = "1"

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -37,7 +37,7 @@ fn expand_named_struct(struct_name: &Ident, fields: &Punctuated<Field, Comma>) -
 
     quote! {
         impl edn_rs::Serialize for #struct_name {
-            fn serialize(&self) -> std::string::String {
+            fn serialize(self) -> std::string::String {
                 let mut s = std::string::String::new();
                 s.push_str("{ ");
                 #(s.push_str(&#it);)*
@@ -58,7 +58,7 @@ fn expand_unnamed_struct(struct_name: &Ident, fields: &Punctuated<Field, Comma>)
 
     quote! {
         impl edn_rs::Serialize for #struct_name {
-            fn serialize(&self) -> std::string::String {
+            fn serialize(self) -> std::string::String {
                 let mut s = std::string::String::from("{ ");
                 #(s.push_str(&#it);)*
                 s.push_str("}");
@@ -71,7 +71,7 @@ fn expand_unnamed_struct(struct_name: &Ident, fields: &Punctuated<Field, Comma>)
 fn expand_unit_struct(struct_name: &Ident) -> TokenStream2 {
     quote! {
         impl edn_rs::Serialize for #struct_name {
-            fn serialize(&self) -> std::string::String {
+            fn serialize(self) -> std::string::String {
                 String::from("nil")
             }
         }
@@ -94,7 +94,7 @@ fn expand_enum(enum_name: &Ident, data_enum: &DataEnum) -> TokenStream2 {
 
     quote! {
         impl edn_rs::Serialize for #enum_name {
-            fn serialize(&self) -> std::string::String {
+            fn serialize(self) -> std::string::String {
                 match self {
                     #(#it)*
                 }

--- a/tests/both_ways.rs
+++ b/tests/both_ways.rs
@@ -10,7 +10,7 @@ struct Point {
 fn main() -> Result<(), EdnError> {
     let point = Point { x: 1, y: 2 };
 
-    let serialized = edn_rs::to_string(&point);
+    let serialized = edn_rs::to_string(point.clone());
     let deserialized: Point = edn_rs::from_str(&serialized)?;
 
     assert_eq!(point, deserialized);

--- a/tests/complex.rs
+++ b/tests/complex.rs
@@ -28,7 +28,7 @@ fn main() -> Result<(), EdnError> {
     let account_edn_str =
         "{ :crux.db/id \"123\", :account/amount 42, :account-type :account-type/premium-plus, }";
 
-    assert_eq!(edn_rs::to_string(&account), account_edn_str);
+    assert_eq!(edn_rs::to_string(account), account_edn_str);
 
     let account: Account = edn_rs::from_str(account_edn_str)?;
 

--- a/tests/serialize.rs
+++ b/tests/serialize.rs
@@ -23,7 +23,7 @@ fn main() {
         kind: Kind::Chill,
     };
     assert_eq!(
-        edn_rs::to_string(&person),
+        edn_rs::to_string(person),
         "{ :name \"joana\", :age 290000, :kind :kind/chill, }"
     );
 }

--- a/tests/unit_struct.rs
+++ b/tests/unit_struct.rs
@@ -1,4 +1,4 @@
-use edn_derive::{Deserialize, Serialize};
+use edn_derive::{Serialize, Deserialize};
 use edn_rs::EdnError;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
@@ -7,19 +7,23 @@ struct Nothing;
 fn main() -> Result<(), EdnError> {
     let nothing = Nothing;
 
-    assert_eq!(edn_rs::to_string(&nothing), "nil");
+    assert_eq!(
+        edn_rs::to_string(nothing),
+        "nil"
+    );
 
     let nothing: Nothing = edn_rs::from_str("nil")?;
 
-    assert_eq!(nothing, Nothing);
+    assert_eq!(
+        nothing,
+        Nothing
+    );
 
     let nothing_err: Result<Nothing, EdnError> = edn_rs::from_str(":a-key");
 
     assert_eq!(
         nothing_err,
-        Err(EdnError::Deserialize(
-            "couldn't convert :a-key into an unit struct".to_string()
-        ))
+        Err(EdnError::Deserialize("couldn't convert :a-key into an unit struct".to_string()))
     );
 
     Ok(())

--- a/tests/unnamed_struct_serialize.rs
+++ b/tests/unnamed_struct_serialize.rs
@@ -16,7 +16,8 @@ fn main() {
     let person = Person("joana".to_string(), 290000, Kind::Chill);
 
     assert_eq!(
-        edn_rs::to_string(&person),
+        edn_rs::to_string(person),
         "{ 0 \"joana\", 1 290000, 2 :kind/chill, }"
     );
 }
+


### PR DESCRIPTION
Reverts edn-rs/edn-derive#37

`edn-rs` is reverting this move to ref for maximum compatibility. No release needs to be made.
https://github.com/edn-rs/edn-rs/pull/156

Reference:
https://github.com/edn-rs/edn-rs/issues/158